### PR TITLE
build: Add automatic module name to artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ task sourcesJar(type: Jar, dependsOn: 'classes') {
     classifier = 'sources'
 }
 
+jar {
+    manifest.attributes("Automatic-Module-Name": "${project.group}.atlas")
+}
+
 artifacts {
     archives javadocJar
     archives sourcesJar


### PR DESCRIPTION
As in the other projects, lets Atlas be used as a direct dependency of a full Java 9+ module.